### PR TITLE
feat: улучшена модерация ивентов

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # java-explore-with-me
 Template repository for ExploreWithMe project.
+
+[Pull request link](https://github.com/Elessarov1/java-explore-with-me/pull/5)

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/controller/admin/EventAdminController.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/controller/admin/EventAdminController.java
@@ -45,4 +45,18 @@ public class EventAdminController {
         log.info("Confirm Or Reject Event {} {}", eventId, request);
         return eventService.confirmOrRejectEvent(eventId, request);
     }
+
+    @GetMapping("/pending")
+    public List<EventFullDto> getAllPendingEvents() {
+        log.info("get all pending events");
+        return eventService.getAllPendingEvents();
+    }
+
+    @PatchMapping("/return/{eventId}")
+    public EventFullDto sendBackForChange(@PathVariable Long eventId,
+                                          @RequestBody String comment) {
+        log.info("send back to change {} {}", eventId, comment);
+        return eventService.sendBackForChange(eventId, comment);
+    }
 }
+

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/controller/priv/EventPrivateController.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/controller/priv/EventPrivateController.java
@@ -73,4 +73,10 @@ public class EventPrivateController {
         log.info("Update event request userId {}, eventId {}, dto {}", userId, eventId, dto);
         return service.updateEventRequest(userId, eventId, dto);
     }
+
+    @GetMapping("/returned")
+    public List<EventFullDto> getReturnedEvents(@PathVariable @NotNull Long userId) {
+        log.info("Get returned events for user {}", userId);
+        return service.getReturnedEvents(userId);
+    }
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/dto/event/EventFullDto.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/dto/event/EventFullDto.java
@@ -30,4 +30,5 @@ public class EventFullDto {
     String title;
     @Builder.Default
     Long views = 0L;
+    String adminComment;
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/dto/event/UpdateEventAfterModerationDto.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/dto/event/UpdateEventAfterModerationDto.java
@@ -1,0 +1,16 @@
+package ru.practicum.ewm.service.dto.event;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UpdateEventAfterModerationDto {
+    @NotBlank
+    String moderatorComment;
+}

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/dto/event/enums/State.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/dto/event/enums/State.java
@@ -1,5 +1,5 @@
 package ru.practicum.ewm.service.dto.event.enums;
 
 public enum State {
-    PENDING, PUBLISHED, CANCELED
+    PENDING, PUBLISHED, CANCELED, RETURNED_FOR_CHANGE
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/entity/Event.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/entity/Event.java
@@ -2,6 +2,7 @@ package ru.practicum.ewm.service.entity;
 
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+import org.springframework.lang.Nullable;
 import ru.practicum.ewm.service.dto.event.enums.State;
 
 import javax.persistence.*;
@@ -47,6 +48,9 @@ public class Event {
     @Builder.Default
     State state = State.PENDING;
     String title;
+    @Column(name = "admin_comment")
+    @Nullable
+    String adminComment;
 
     @PrePersist
     public void prePersist() {

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/repository/EventRepository.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/repository/EventRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import ru.practicum.ewm.service.dto.event.enums.State;
 import ru.practicum.ewm.service.entity.Event;
 
 import java.util.List;
@@ -15,4 +16,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByInitiatorIdOrderByCreatedOn(Long userId, PageRequest page);
 
     boolean existsByCategoryId(Long catId);
+
+    List<Event> findAllByStateIsOrderByCreatedOn(State state);
+
+    List<Event> findAllByInitiatorIdAndStateIs(Long userId, State state);
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/service/admin/EventAdminService.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/service/admin/EventAdminService.java
@@ -32,11 +32,11 @@ import static ru.practicum.ewm.service.util.DefaultValues.*;
 @Service
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Transactional(readOnly = true)
 public class EventAdminService {
     EventRepository eventRepository;
     StatsService statsService;
 
-    @Transactional(readOnly = true)
     public List<EventFullDto> searchEvents(List<Long> users,
                                            State states,
                                            List<Long> categories,
@@ -76,6 +76,21 @@ public class EventAdminService {
             return EventMapper.toDto(event);
         }
         event.setState(State.CANCELED);
+        return EventMapper.toDto(event);
+    }
+
+    public List<EventFullDto> getAllPendingEvents() {
+        return EventMapper.toDtoList(
+                eventRepository.findAllByStateIsOrderByCreatedOn(State.PENDING)
+        );
+    }
+
+    @Transactional
+    public EventFullDto sendBackForChange(Long eventId, String comment) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new NotFoundException("no such event"));
+        event.setAdminComment(comment);
+        event.setState(State.RETURNED_FOR_CHANGE);
         return EventMapper.toDto(event);
     }
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/service/priv/EventPrivateService.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/service/priv/EventPrivateService.java
@@ -105,6 +105,7 @@ public class EventPrivateService {
         event.setState(State.PENDING);
         if (dto.getStateAction() != null && dto.getStateAction().equals(StateAction.CANCEL_REVIEW))
             event.setState(State.CANCELED);
+        event.setAdminComment("");
         BeanUtils.copyProperties(dto, event, getNullPropertyNames(dto));
         return EventMapper.toDto(event);
     }
@@ -162,5 +163,11 @@ public class EventPrivateService {
     private Event getEventIfExist(Long eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new NotFoundException("no such event"));
+    }
+
+    public List<EventFullDto> getReturnedEvents(Long userId) {
+        return EventMapper.toDtoList(
+                eventRepository.findAllByInitiatorIdAndStateIs(userId, State.RETURNED_FOR_CHANGE)
+        );
     }
 }

--- a/ewm-service/src/main/java/ru/practicum/ewm/service/util/mapper/EventMapper.java
+++ b/ewm-service/src/main/java/ru/practicum/ewm/service/util/mapper/EventMapper.java
@@ -38,6 +38,7 @@ public class EventMapper {
                 .requestModeration(event.getRequestModeration())
                 .category(CategoryMapper.toDto(event.getCategory()))
                 .annotation(event.getAnnotation())
+                .adminComment(event.getAdminComment())
                 .build();
     }
 

--- a/ewm-service/src/main/resources/schema.sql
+++ b/ewm-service/src/main/resources/schema.sql
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS events (
    published_on       TIMESTAMP,
    request_moderation BOOLEAN,
    state              VARCHAR(30),
-   title              VARCHAR(120)
+   title              VARCHAR(120),
+   admin_comment      VARCHAR(1000)
 );
 
 CREATE TABLE IF NOT EXISTS requests (

--- a/postman/feature.json
+++ b/postman/feature.json
@@ -1,0 +1,269 @@
+{
+	"info": {
+		"_postman_id": "c21092da-1972-4e9b-8dda-04c7bae0316d",
+		"name": "feature",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "26021844"
+	},
+	"item": [
+		{
+			"name": "Add User",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function() {\r",
+							"    pm.expect(pm.response.code).to.equal(201); // код ответа должен быть равен 201 OK\r",
+							"    pm.response.to.be.withBody; // ответ должен содержать тело\r",
+							"    pm.response.to.be.json; // и тело ответа должно быть в формате JSON\r",
+							"}); "
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"name\":\"Mr.User_feature\",\"email\":\"user_feature@gmail.com\"}"
+				},
+				"url": {
+					"raw": "localhost:8080/admin/users",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"admin",
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add category",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function() {\r",
+							"    pm.expect(pm.response.code).to.equal(201); // код ответа должен быть равен 201 OK\r",
+							"    pm.response.to.be.withBody; // ответ должен содержать тело\r",
+							"    pm.response.to.be.json; // и тело ответа должно быть в формате JSON\r",
+							"}); "
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"name\":\"feature_category\"}"
+				},
+				"url": {
+					"raw": "localhost:8080/admin/categories",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"admin",
+						"categories"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add event",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function() {\r",
+							"    pm.expect(pm.response.code).to.equal(201); // код ответа должен быть равен 201 OK\r",
+							"    pm.response.to.be.withBody; // ответ должен содержать тело\r",
+							"    pm.response.to.be.json; // и тело ответа должно быть в формате JSON\r",
+							"}); "
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\"annotation\":\"feature annotation-----------------------------------------.\",\r\n\"category\":1,\r\n\"description\":\"feature description-----------------------------------.\",\r\n\"eventDate\":\"2023-08-05 05:14:44\",\r\n\"location\":{\r\n    \"lat\":-8.0441,\r\n    \"lon\":-39.1419\r\n    },\r\n    \"paid\":\"true\",\r\n    \"participantLimit\":\"25\",\r\n    \"requestModeration\":\"false\",\r\n    \"title\":\"feature title.\"\r\n    }"
+				},
+				"url": {
+					"raw": "localhost:8080/users/1/events",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"users",
+						"1",
+						"events"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get pending events",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function() {\r",
+							"    pm.response.to.be.ok; // код ответа должен быть равен 200 OK\r",
+							"    pm.response.to.be.withBody; // ответ должен содержать тело\r",
+							"    pm.response.to.be.json; // и тело ответа должно быть в формате JSON\r",
+							"}); "
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8080/admin/events/pending",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"admin",
+						"events",
+						"pending"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Patch event",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function() {\r",
+							"    pm.response.to.be.ok; // код ответа должен быть равен 200 OK\r",
+							"    pm.response.to.be.withBody; // ответ должен содержать тело\r",
+							"    pm.response.to.be.json; // и тело ответа должно быть в формате JSON\r",
+							"}); "
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disabledSystemHeaders": {}
+			},
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text",
+						"disabled": true
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "you should change the description"
+				},
+				"url": {
+					"raw": "localhost:8080/admin/events/return/1",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"admin",
+						"events",
+						"return",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get events after moderation",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function() {\r",
+							"    pm.response.to.be.ok; // код ответа должен быть равен 200 OK\r",
+							"    pm.response.to.be.withBody; // ответ должен содержать тело\r",
+							"    pm.response.to.be.json; // и тело ответа должно быть в формате JSON\r",
+							"}); "
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "localhost:8080/users/1/events/returned",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"users",
+						"1",
+						"events",
+						"returned"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/stat-service/client/src/main/java/ru/practicum/stat/client/StatClient.java
+++ b/stat-service/client/src/main/java/ru/practicum/stat/client/StatClient.java
@@ -16,9 +16,8 @@ import java.util.Map;
 
 @Service
 public class StatClient extends BaseClient {
-    /*For the local tests
-    private static final String SERVER_URL = "http://localhost:9090";
-    */
+    //For the local tests
+    //private static final String SERVER_URL = "http://localhost:9090";
     private static final String SERVER_URL = "http://stats-server:9090";
     private static final String HIT_ENDPOINT = "/hit";
     private static final String STATS_ENDPOINT = "/stats";


### PR DESCRIPTION
Добавил модерацию.
1. {baseurl}/admin/events/pending - админ получает список ивентов со статусом PENDING
2. {baseurl}/admin/events/return/{{eventId}} - админ добавляет комментарий к ивенту. Статус ивента меняется на RETURNED_FOR_CHANGE
3. {baseurl}/users/{{userId}}/events/returned - юзер может запросить список возвращенных ивентов с комментариями от админа
4. {baseurl}/users/{{userId}}/events/{{eventId}} - юзер меняет ивент согласно указаниям, статус меняется на PENDING, комментарий админа удаляется